### PR TITLE
Fix window resize-ability.

### DIFF
--- a/CornFeed/Form1.cs
+++ b/CornFeed/Form1.cs
@@ -153,8 +153,9 @@ namespace CornFeed
         {
             if (m.Msg == WM_NCHITTEST)
             {
-                int x = (int)(m.LParam.ToInt64() & 0xFFFF);
-                int y = (int)((m.LParam.ToInt64() >> 16) & 0xFFFF);
+                uint lparam32 = (uint)m.LParam.ToInt64();
+                short x = (short)((uint)lparam32 & 0xFFFF);
+                short y = (short)(((uint)lparam32 >> 16) & 0xFFFF);
                 Point cursor = PointToClient(new Point(x, y));
 
                 // Enable resizing


### PR DESCRIPTION
I was unable to move the window using the existing code--anywhere I put the mouse outside of buttons/text fields I was only provided with the vertical resize option.

https://github.com/user-attachments/assets/6a26f281-cfc7-40e2-a013-f096d77633af

With the following changes (inspired by the recommendation in [this stack overflow post](https://stackoverflow.com/a/49288716)) I'm now able to move the window and resize appropriately.

https://github.com/user-attachments/assets/6a565cde-9ed1-4141-a2a2-79d74efc8294

I'm on Windows 11 if that helps!